### PR TITLE
Fixing typo: /usr/local/bin/cf-mgmt NOT /usr/local/bin/cf-mgmta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends ${PACKAGES} && 
     ln -s /usr/local/bin/yq /usr/local/bin/yaml && \
     curl -L "https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERION}/spruce-linux-amd64" -o spruce && chmod +x spruce && mv spruce /usr/local/bin/spruce && \
     curl -L "https://github.com/go-swagger/go-swagger/releases/download/${SWAGGER_VERION}/swagger_linux_amd64" -o swagger && chmod +x swagger && mv swagger /usr/local/bin/swagger && \
-    curl -L "https://github.com/pivotalservices/cf-mgmt/releases/download/${CF_MGMT_VERSION}/cf-mgmt-linux" -o /usr/local/bin/cf-mgmta && chmod +x /usr/local/bin/cf-mgmt && \
+    curl -L "https://github.com/pivotalservices/cf-mgmt/releases/download/${CF_MGMT_VERSION}/cf-mgmt-linux" -o /usr/local/bin/cf-mgmt && chmod +x /usr/local/bin/cf-mgmt && \
     curl -L "https://github.com/pivotalservices/cf-mgmt/releases/download/${CF_MGMT_VERSION}/cf-mgmt-config-linux" -o /usr/local/bin/cf-mgmt-config && chmod +x /usr/local/bin/cf-mgmt-config && \
     ln /usr/bin/uuidgen /usr/local/bin/uuid && \
     cf install-plugin -r CF-Community -f "blue-green-deploy" && \


### PR DESCRIPTION
I made a typo and the build filed.

It should be /usr/local/bin/cf-mgmt NOT /usr/local/bin/cf-mgmta