### PR TITLE
Default cipher strength not compatible with current LB config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ RUN ln /usr/bin/uuidgen /usr/local/bin/uuid && \
     go get -v github.com/onsi/ginkgo/ginkgo && \
     go get -v github.com/onsi/gomega/... && \
     go get -v github.com/EngineerBetter/stopover && \
-    rm -rf /tmp/autopilot-linux $GOPATH/src
+    rm -rf /tmp/autopilot-linux $GOPATH/src && \
+    sed -i 's/^CipherString/#CipherString/g' /etc/ssl/openssl.cnf
+


### PR DESCRIPTION
Curl has problems in UK envs due to LB config. Removing the CipherStrength line allows us to work around the issue until the config gets fixed.