### PR TITLE
TPR: golang version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster
+FROM golang:1.16-buster
 ENV CF_CLI_VERSION="7.2.0"
 ENV YQ_VERSION="3.2.1"
 ENV SPRUCE_VERION="1.25.2"


### PR DESCRIPTION
to 1.16 to follow latest releases for our software